### PR TITLE
Channel meta

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function feedMetaTags({ title, description, link, copyright, generator, docs, op
       { 'itunes:type': 'episodic' },
       { 'itunes:owner': contactInfo(title, 'neil.janowitz@vulture.com') },
       { 'itunes:image': 'http://pixel.nymag.com/imgs/daily/vulture/2018/08/21/Vulture3000x3000.jpg' },
-      { 'itunes:category': [{ _attr: { text: 'Entertainment'} }]},
+      { 'itunes:category': [{ _attr: { text: 'Entertainment'} }] },
       { 'itunes:explicit': 'no' }
     ];
 

--- a/index.js
+++ b/index.js
@@ -31,11 +31,11 @@ function elevateCategory(group) {
  * @param {string} email
  * @returns {Array}
  */
-function contactInfo (name, email) {
+function contactInfo(name, email) {
   return [
     { 'itunes:name': name },
     { 'itunes:email': email }
-  ]
+  ];
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -53,7 +53,16 @@ function feedMetaTags({ title, description, link, copyright, generator, docs, op
       { lastBuildDate: format(now, 'ddd, DD MMM YYYY HH:mm:ss ZZ') }, // Date format must be RFC 822 compliant
       { docs: docs || 'http://blogs.law.harvard.edu/tech/rss' },
       { copyright: copyright || now.getFullYear() },
-      { generator: generator || 'Feed delivered by Clay' }
+      { generator: generator || 'Feed delivered by Clay' },
+      { language: 'en-us' },
+      { 'itunes:subtitle': description },
+      { 'itunes:author': title },
+      { 'itunes:summary': description },
+      { 'itunes:type': 'episodic' },
+      { 'itunes:owner': contactInfo(title, 'neil.janowitz@vulture.com') },
+      { 'itunes:image': 'http://pixel.nymag.com/imgs/daily/vulture/2018/08/21/Vulture3000x3000.jpg' },
+      { 'itunes:category': [{ _attr: { text: 'Entertainment'} }]},
+      { 'itunes:explicit': 'no' }
     ];
 
     if (opt) {

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function feedMetaTags({ title, description, link, copyright, generator, docs, op
       { 'itunes:type': 'episodic' },
       { 'itunes:owner': contactInfo(title, 'neil.janowitz@vulture.com') },
       { 'itunes:image': 'http://pixel.nymag.com/imgs/daily/vulture/2018/08/21/Vulture3000x3000.jpg' },
-      { 'itunes:category': [{ _attr: { text: 'Entertainment'} }] },
+      { 'itunes:category': [{ _attr: { text: 'Entertainment'} }]},
       { 'itunes:explicit': 'no' }
     ];
 

--- a/index.js
+++ b/index.js
@@ -26,6 +26,19 @@ function elevateCategory(group) {
 }
 
 /**
+ *
+ * @param {string} name
+ * @param {string} email
+ * @returns {Array}
+ */
+function contactInfo (name, email) {
+  return [
+    { 'itunes:name': name },
+    { 'itunes:email': email }
+  ]
+}
+
+/**
  * Add the meta tags around the feed
  *
  * @param  {String} title


### PR DESCRIPTION
Apple requested we update our `channel` element on our rss feed so it looks like theirs. We needed to add `itunes:` elements to our channel, so I added it to the meta object. These new tags update the `<channel>` to incorporate the new requirements. I know this will add these meta tags to all rss-feeds. Please let me know if theres a better way to do this, thanks 

https://help.apple.com/itc/podcasts_connect/#/itcbaf351599