### PR TITLE
Rename `attr` to `namespaces`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,21 @@ This renderer is highly dependent on the component API provided by Amphora and t
 ## Data Specification
 
 ## Updating Namespaces
- This renderer has default namespaces which gets injected at the top of the rss feed. These namespaces are contained inside of the `defaultNamespaces` object. The namespaces can be overridden, removed or extended by attaching namespaces to the `attr` object. Since we merge this `attr` with `defaultNamespaces` and remove null values, attr keys with null values will not be included in the feed. attr keys with different namespaces will be added as an additional namespace to the feed. If a key holds the same namespace which exists within `defaultNamespaces` (and the value is not null) we will use the value of the attr namespace.
- - To remove a default namespace, set the value of that namespace to `null` inside the `attr` object. To modify a namespace, change the value of that similar namespace inside the `attr` object. To add a new namespace, add a key:value pair to the `attr` object where the key is a namespace that isn't used within `defaultNamespaces`, and the value is the url.
-  - ```
-  defaultNamespaces: {
-      version: '2.0',
-      'xmlns:content': 'http://purl.org/rss/1.0/modules/content/',
-      'xmlns:mi': 'http://schemas.ingestion.microsoft.com/common/',
-      'xmlns:dc': 'http://purl.org/dc/elements/1.1/',
-      }
-
-  attr: {
-      "xmlns:itunes": "http://www.itunes.com/dtds/podcast-1.0.dtd", <!-- this will be an additional namespace in our feed -->
-      "xmlns:mi": null, <!-- this will be removed from our feed -->
-      "xmlns:dc": "http://purl.org/dc/elements/2.1/", <!-- this will override and be the updated namespace -->
-      }
+This renderer has default namespaces which gets injected at the top of the rss feed. These namespaces are contained inside of the `defaultNamespaces` object. The namespaces can be overridden, removed or extended by attaching namespaces to the `namespaces` object. Since we merge this `namespaces` with `defaultNamespaces` and remove null values, namespaces keys with null values will not be included in the feed. namespaces keys with different namespaces will be added as an additional namespace to the feed. If a key holds the same namespace which exists within `defaultNamespaces` (and the value is not null) we will use the value of the attr namespace.
+- To remove a default namespace, set the value of that namespace to `null` inside the `namespaces` object. To modify a namespace, change the value of that similar namespace inside the `namespaces` object. To add a new namespace, add a key:value pair to the `namespaces` object where the key is a namespace that isn't used within `defaultNamespaces`, and the value is the url.
+  ```js
+  "defaultNamespaces": {
+    "xmlns:content": "http://purl.org/rss/1.0/modules/content/",
+    "xmlns:mi": "http://schemas.ingestion.microsoft.com/common/",
+    "xmlns:dc": "http://purl.org/dc/elements/1.1/"
+  }
+  ```
+  ```js
+  namespaces: {
+    "xmlns:itunes": "http://www.itunes.com/dtds/podcast-1.0.dtd", // this will be an additional namespace in our feed
+    "xmlns:mi": null, // this will be removed from our feed
+    "xmlns:dc": "http://purl.org/dc/elements/2.1/", // this will override and be the updated namespace
+  }
   ```
 
 ### `feed` Array

--- a/index.js
+++ b/index.js
@@ -84,21 +84,24 @@ function cleanNullValues(obj) {
  * Wraps content in top level RSS and Channel tags
  *
  * @param  {Array} data
- * @param  {Object} attr
+ * @param  {Object} namespaces
  * @return {Object}
  */
-function wrapInTopLevel(data, attr = {}) {
-  const defaultNamespaces = {
-    version: '2.0',
-    'xmlns:content': 'http://purl.org/rss/1.0/modules/content/',
-    'xmlns:mi': 'http://schemas.ingestion.microsoft.com/common/',
-    'xmlns:dc': 'http://purl.org/dc/elements/1.1/',
-    'xmlns:media': 'http://search.yahoo.com/mrss/'
-  };
+function wrapInTopLevel(data, namespaces = {}) {
+  const baseTopLevelAttributes = {
+      version: '2.0'
+    },
+    defaultNamespaces = {
+      'xmlns:content': 'http://purl.org/rss/1.0/modules/content/',
+      'xmlns:mi': 'http://schemas.ingestion.microsoft.com/common/',
+      'xmlns:dc': 'http://purl.org/dc/elements/1.1/',
+      'xmlns:media': 'http://search.yahoo.com/mrss/'
+    },
+    combinedNamespaces = cleanNullValues(Object.assign(defaultNamespaces, namespaces));
 
   return {
     rss: [{
-      _attr: cleanNullValues(Object.assign(defaultNamespaces, attr))
+      _attr: Object.assign(baseTopLevelAttributes, combinedNamespaces)
     }, {
       channel: data
     }]
@@ -134,12 +137,12 @@ function sendError(res, e, message = e.message) {
  * @param  {Object} res
  * @return {Promise}
  */
-function render({ feed, meta, attr }, info, res) {
+function render({ feed, meta, namespaces }, info, res) {
   return h(feed)
     .map(wrapInItem)
     .collect()
     .map(feedMetaTags(meta))
-    .map(data => wrapInTopLevel(data, attr))
+    .map(data => wrapInTopLevel(data, namespaces))
     .errors(e => sendError(res, e))
     .toPromise(Promise)
     .then(data => {


### PR DESCRIPTION
Updates the previously called `attr` property to be `namespaces` as that its what it does when wrapping the RSS content in a top level tag.  In the future if other top level tag attributes are required there should be additional properties passed in a similar manner.

*Note*: this will be a breaking change for any existing users of this package