### PR TITLE
🍕 Make elevating categories optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function feedMetaTags(data) {
     copyright,
     description,
     docs = docsUrl,
-    shouldElevateChannelCategories = false,
+    shouldElevateChannelCategories = true,
     generator = generatorMessage,
     image,
     link,


### PR DESCRIPTION
Our feed had `category` items and was pulling them up to the highest level
<img width="1022" height="758" alt="image" src="https://github.com/user-attachments/assets/bd798c6d-0e27-4091-a7d0-7705106375fd" />


We do not want that, so I'm making this behaviour optional so that it doesn't always do that!
<img width="1121" height="624" alt="image" src="https://github.com/user-attachments/assets/0f6f7a8b-26f6-4679-81c8-c27ddf0ba09b" />
